### PR TITLE
add travis deployment to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+branches:
+  only:
+    - master
+
+before_script: bash ./bin/build.sh
+
+script:
+    - ls -al js/gsimaps.min.js
+
+after_success: bash ./bin/deploy.sh
+
+env:
+  global:
+  - GH_REF: github.com/miya0001/sandmaps.github.io.git
+  - secure: "o/cCKTYmJNLiRE1134pQ4bpXkQT3dKj582IMBxN/AMX3QmI8bP8Sd0+KTwl3EV5bjJMD6w/IB//3rx1sXSshHgaCSPBdhINWPraQppBetFKGWOv6v2LSmGZxjJxjymY7Ib9Il0vNDAZXhq5evpPTXou73HRnwELyw0QGnPUEjf2pJaKjHWuVu1SzZquHAl7vc/VCA2R0DCR82ZEVHooX2GpiH6Xu6WlS5+lrWprHvXO3oLbbSsb/vqf1utgmx96ggs/vHuyYaUll3h0kQ3HY0nM+pEwOGXt1XQDQFfjNCnnWyzSYfGqKxtoWEXxExGV8ymnpY+8KSk6AxBlbv13iadhqPS48hKqf1fpz6LpTEW2CZq5STRHo+l/7by5FlgbhRVUimepkjyVGrspluP/WbE7ttZwFUDpF8gr2JhO9bgNbfcZUaj5MrRHuCyv2nFsaOBXn3zP/t2xfDwh3bfyE+RIf9z6GUvqSYNL0BpCpqH2FzlHvOyQClG7SuX8Do5rL2lw0xtB71AiSQg5UU1BDKLiyzxClJ1PjpBOHgJtp5sK92CesKFTVJjXrYDDLTQqrBJHySQwTKLiQq/0o8Tor4VWk0Oz96SZ5AwcGtwo1zQ4MphxGMxSSimqV9eS/8ISvhrRl4iXC+PMmNTBLkpHhAlULHC7q/M+KLtj0ZsderpU="

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+npm install
+npm run build

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "false" != "$TRAVIS_PULL_REQUEST" ]]; then
+	echo "Not deploying pull requests."
+	exit
+fi
+
+if [[ "master" != "$TRAVIS_BRANCH" ]]; then
+	echo "Not on the 'master' branch."
+	exit
+fi
+
+
+# commit to gh-pages
+rm -rf .git
+rm -r .gitignore
+
+echo ".bowerrc
+.travis.yml
+bin
+bower.json
+gulpfile.js
+node_modules
+package.json
+tests" > .gitignore
+
+git init
+git config user.name "Travis CI"
+git config user.email "miya+github.com@wpist.me"
+git add .
+git commit --quiet -m "Deploy from travis"
+git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:gh-pages > /dev/null 2>&1


### PR DESCRIPTION
Travis CIを使用した自動デプロイに必要なファイルを追加
- .travis.yml - Travis CIの設定ファイル。
- bin/build.sh - 地図アプリをビルドするためのシェルスクリプト
- bin/deploy.sh - 地図アプリをgh-pagesにデプロイするためのシェルスクリプト
## 動作例
- https://github.com/miya0001/sandmaps.github.io
- http://miya0001.github.io/sandmaps.github.io.
## Travisからgh-pagesにpushさせるために必要なパーミッションの設定について
### 1. 以下のページでTravis CIようのアクセストークンを生成してください。

https://github.com/settings/tokens

このアクセストークンは次回以降表示されませんので大切に保管してください。

![](https://www.evernote.com/l/ABV8uaA98glNa5qsw3MqvFYWL8mpCd5_B4MB/image.png)

アクセストークンが外部に漏れないようにくれぐれもご注意ください。
### 2. Travis Gemでアクセストークンを暗号化してください。

```
$ gem install travis
$ travis encrypt GH_TOKEN=xxxx
```

`xxxx`の部分はGitHubで取得したトークンに置き換えてください。

コマンドが成功すると以下のようにトークンを暗号化したテキストが出力されます。

```
secure: "o/cCKTYmJNLiRE1134pQ4bpXkQT3dKj582IMBxN/AMX3QmI8bP8Sd0+KTwl3EV5bjJMD6w/IB//3rx1sXSshHgaCSPBdhINWPraQppBetFKGWOv6v2LSmGZxjJxjymY7Ib9Il0vNDAZXhq5evpPTXou73HRnwELyw0QGnPUEjf2pJaKjHWuVu1SzZquHAl7vc/VCA2R0DCR82ZEVHooX2GpiH6Xu6WlS5+lrWprHvXO3oLbbSsb/vqf1utgmx96ggs/vHuyYaUll3h0kQ3HY0nM+pEwOGXt1XQDQFfjNCnnWyzSYfGqKxtoWEXxExGV8ymnpY+8KSk6AxBlbv13iadhqPS48hKqf1fpz6LpTEW2CZq5STRHo+l/7by5FlgbhRVUimepkjyVGrspluP/WbE7ttZwFUDpF8gr2JhO9bgNbfcZUaj5MrRHuCyv2nFsaOBXn3zP/t2xfDwh3bfyE+RIf9z6GUvqSYNL0BpCpqH2FzlHvOyQClG7SuX8Do5rL2lw0xtB71AiSQg5UU1BDKLiyzxClJ1PjpBOHgJtp5sK92CesKFTVJjXrYDDLTQqrBJHySQwTKLiQq/0o8Tor4VWk0Oz96SZ5AwcGtwo1zQ4MphxGMxSSimqV9eS/8ISvhrRl4iXC+PMmNTBLkpHhAlULHC7q/M+KLtj0ZsderpU="
```

これをコピーしてください。
### 3. `.travis.yml` に追記してください。

`.travis.yml`にすでに私のトークンが記述されていますので上でコピーしたものと置き換えてください。

また以下の行も

```
- GH_REF: github.com/miya0001/sandmaps.github.io.git
```

以下のように書き換えてください。

```
- GH_REF: github.com/sandmaps/sandmaps.github.io.git
```

以上が適切に完了するとmasterブランチにpushされた時にgh-pagesにデプロイされます。

masterブランチ以外のブランチにpushされた場合、プルリクエストの場合はデプロイされません。
